### PR TITLE
Update Preact to 7.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "uglify-js": "^2.6.1"
   },
   "dependencies": {
-    "preact": "^4.1.0"
+    "preact": "^7.1.0"
   }
 }


### PR DESCRIPTION
As per our discussion on Twitter a little while ago, there were issues using `preact` 7.x with the current version of `preact-cycle` and it affected the compatibility of the `preact/devtools`.

This bumps the `preact` dependency version to "latest" and should hopefully avoid double loading `preact` `4.x` and `7.x` in projects where `preact` and `preact-cycle` is used.